### PR TITLE
Add async guardrail hooks

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -524,6 +524,24 @@ except UnexpectedModelBehavior as e:
 
 1. This error is raised because the safety thresholds were exceeded.
 
+#### Guardrail callbacks
+
+You can register asynchronous callbacks that inspect the message history after each model response.
+Guardrails run concurrently with the agent and are awaited before the final result is returned.
+
+```python {title="guardrail.py"}
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ModelMessage
+
+agent = Agent('openai:gpt-4o')
+
+@agent.guardrail
+async def log_response(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+    print('Latest response:', messages[-1])
+
+result = agent.run_sync('Hello')
+```
+
 ## Runs vs. Conversations
 
 An agent **run** might represent an entire conversation — there's no limit to how many messages can be exchanged in a single run. However, a **conversation** might also be composed of multiple runs, especially if you need to maintain state between separate interactions or API calls.

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -34,6 +34,7 @@ __all__ = (
     'build_run_context',
     'capture_run_messages',
     'HistoryProcessor',
+    'Guardrail',
 )
 
 
@@ -66,6 +67,8 @@ HistoryProcessor = Union[
 Can optionally accept a `RunContext` as a parameter.
 """
 
+Guardrail = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
+
 
 @dataclasses.dataclass
 class GraphAgentState:
@@ -75,6 +78,7 @@ class GraphAgentState:
     usage: _usage.Usage
     retries: int
     run_step: int
+    guardrail_tasks: list[asyncio.Task[Any]] = dataclasses.field(default_factory=list, repr=False)
 
     def increment_retries(self, max_result_retries: int, error: Exception | None = None) -> None:
         self.retries += 1
@@ -106,6 +110,7 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     output_validators: list[_output.OutputValidator[DepsT, OutputDataT]]
 
     history_processors: Sequence[HistoryProcessor[DepsT]]
+    guardrails: Sequence[Guardrail[DepsT]]
 
     function_tools: dict[str, Tool[DepsT]] = dataclasses.field(repr=False)
     mcp_servers: Sequence[MCPServer] = dataclasses.field(repr=False)
@@ -403,6 +408,13 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
         # Append the model response to state.message_history
         ctx.state.message_history.append(response)
+
+        # Trigger guardrail callbacks asynchronously
+        if ctx.deps.guardrails:
+            run_context = build_run_context(ctx)
+            for guardrail in ctx.deps.guardrails:
+                task = asyncio.create_task(guardrail(ctx.state.message_history, run_context))
+                ctx.state.guardrail_tasks.append(task)
 
         # Set the `_result` attribute since we can't use `return` in an async iterator
         self._result = CallToolsNode(response)

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import asyncio
 import dataclasses
 import inspect
 import json
@@ -28,7 +29,7 @@ from . import (
     result,
     usage as _usage,
 )
-from ._agent_graph import HistoryProcessor
+from ._agent_graph import Guardrail, HistoryProcessor
 from .models.instrumented import InstrumentationSettings, InstrumentedModel, instrument_model
 from .result import FinalResult, OutputDataT, StreamedRunResult
 from .settings import ModelSettings, merge_model_settings
@@ -75,6 +76,7 @@ __all__ = (
     'ModelRequestNode',
     'UserPromptNode',
     'InstrumentationSettings',
+    'Guardrail',
 )
 
 
@@ -181,6 +183,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        guardrails: Sequence[Guardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     @overload
@@ -211,6 +214,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        guardrails: Sequence[Guardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     def __init__(
@@ -236,6 +240,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        guardrails: Sequence[Guardrail[AgentDepsT]] | None = None,
         **_deprecated_kwargs: Any,
     ):
         """Create an agent.
@@ -282,6 +287,9 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             history_processors: Optional list of callables to process the message history before sending it to the model.
                 Each processor takes a list of messages and returns a modified list of messages.
                 Processors can be sync or async and are applied in sequence.
+            guardrails: Optional list of async callbacks that receive the message history and run context
+                after each model response. Guardrails are executed concurrently with agent execution,
+                and all tasks must finish before the run result is returned.
         """
         if model is None or defer_model_check:
             self.model = model
@@ -351,6 +359,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self._mcp_servers = mcp_servers
         self._prepare_tools = prepare_tools
         self.history_processors = history_processors or []
+        self.guardrails = guardrails or []
         for tool in tools:
             if isinstance(tool, Tool):
                 self._register_tool(tool)
@@ -647,6 +656,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             usage=usage,
             retries=0,
             run_step=0,
+            guardrail_tasks=[],
         )
 
         # We consider it a user error if a user tries to restrict the result type while having an output validator that
@@ -699,6 +709,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             output_schema=output_schema,
             output_validators=output_validators,
             history_processors=self.history_processors,
+            guardrails=self.guardrails,
             function_tools=run_function_tools,
             mcp_servers=self._mcp_servers,
             default_retries=self._default_retries,
@@ -725,6 +736,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             ) as graph_run:
                 agent_run = AgentRun(graph_run)
                 yield agent_run
+                if graph_run.state.guardrail_tasks:
+                    await asyncio.gather(*graph_run.state.guardrail_tasks)
                 if (final_result := agent_run.result) is not None and run_span.is_recording():
                     run_span.set_attribute(
                         'final_result',
@@ -1309,6 +1322,32 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
 
     @deprecated('`result_validator` is deprecated, use `output_validator` instead.')
     def result_validator(self, func: Any, /) -> Any: ...
+
+    @overload
+    def guardrail(self, func: Guardrail[AgentDepsT], /) -> Guardrail[AgentDepsT]: ...
+
+    @overload
+    def guardrail(self, /) -> Callable[[Guardrail[AgentDepsT]], Guardrail[AgentDepsT]]: ...
+
+    def guardrail(
+        self,
+        func: Guardrail[AgentDepsT] | None = None,
+    ) -> Guardrail[AgentDepsT] | Callable[[Guardrail[AgentDepsT]], Guardrail[AgentDepsT]]:
+        """Decorator to register an asynchronous guardrail callback.
+
+        The callback receives the full message history and `RunContext` after each model response.
+        It runs concurrently with the agent execution and is awaited before returning the final result.
+        """
+        if func is None:
+
+            def decorator(func_: Guardrail[AgentDepsT]) -> Guardrail[AgentDepsT]:
+                self.guardrails.append(func_)
+                return func_
+
+            return decorator
+        else:
+            self.guardrails.append(func)
+            return func
 
     @overload
     def tool(self, func: ToolFuncContext[AgentDepsT, ToolParams], /) -> ToolFuncContext[AgentDepsT, ToolParams]: ...


### PR DESCRIPTION
## Summary
- add guardrail callback API to `Agent`
- trigger guardrail callbacks after each model response
- wait for callbacks before finishing agent runs
- document guardrails in Agent docs

## Testing
- `ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6855dac8afa0832a9bae184e5a85ada1