### PR TITLE
Add async guardrail hooks

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -553,6 +553,25 @@ print(result2.output)
 
 _(This example is complete, it can be run "as is")_
 
+## Asynchronous guardrails
+
+Guardrails are async callbacks that run beside the agent after each model response.
+They receive the full message history and a [`RunContext`][pydantic_ai.tools.RunContext].
+Guardrails are awaited before the agent run finishes, allowing you to integrate
+custom validation or logging logic.
+
+```python {title="guardrails.py"}
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ModelMessage
+
+agent = Agent('openai:gpt-4o')
+
+@agent.guardrail
+async def check_messages(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+    if any('forbidden' in getattr(m, 'content', '') for m in messages):
+        print('forbidden content detected')
+```
+
 ## Type safe by design {#static-type-checking}
 
 PydanticAI is designed to work well with static type checkers, like mypy and pyright.

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -34,6 +34,7 @@ __all__ = (
     'build_run_context',
     'capture_run_messages',
     'HistoryProcessor',
+    'Guardrail',
 )
 
 
@@ -66,6 +67,9 @@ HistoryProcessor = Union[
 Can optionally accept a `RunContext` as a parameter.
 """
 
+Guardrail = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
+"""A callback executed asynchronously after each model response."""
+
 
 @dataclasses.dataclass
 class GraphAgentState:
@@ -75,6 +79,7 @@ class GraphAgentState:
     usage: _usage.Usage
     retries: int
     run_step: int
+    guardrail_tasks: list[asyncio.Task[Any]] = field(default_factory=list, repr=False)
 
     def increment_retries(self, max_result_retries: int, error: Exception | None = None) -> None:
         self.retries += 1
@@ -106,6 +111,7 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     output_validators: list[_output.OutputValidator[DepsT, OutputDataT]]
 
     history_processors: Sequence[HistoryProcessor[DepsT]]
+    guardrails: Sequence[Guardrail[DepsT]]
 
     function_tools: dict[str, Tool[DepsT]] = dataclasses.field(repr=False)
     mcp_servers: Sequence[MCPServer] = dataclasses.field(repr=False)
@@ -403,6 +409,11 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
         # Append the model response to state.message_history
         ctx.state.message_history.append(response)
+
+        run_ctx = build_run_context(ctx)
+        for guardrail in ctx.deps.guardrails:
+            task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+            ctx.state.guardrail_tasks.append(task)
 
         # Set the `_result` attribute since we can't use `return` in an async iterator
         self._result = CallToolsNode(response)

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import dataclasses
+import asyncio
 import inspect
 import json
 import warnings
@@ -28,7 +29,7 @@ from . import (
     result,
     usage as _usage,
 )
-from ._agent_graph import HistoryProcessor
+from ._agent_graph import HistoryProcessor, Guardrail
 from .models.instrumented import InstrumentationSettings, InstrumentedModel, instrument_model
 from .result import FinalResult, OutputDataT, StreamedRunResult
 from .settings import ModelSettings, merge_model_settings
@@ -181,6 +182,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        guardrails: Sequence[Guardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     @overload
@@ -211,6 +213,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        guardrails: Sequence[Guardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     def __init__(
@@ -236,6 +239,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        guardrails: Sequence[Guardrail[AgentDepsT]] | None = None,
         **_deprecated_kwargs: Any,
     ):
         """Create an agent.
@@ -282,6 +286,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             history_processors: Optional list of callables to process the message history before sending it to the model.
                 Each processor takes a list of messages and returns a modified list of messages.
                 Processors can be sync or async and are applied in sequence.
+            guardrails: Optional list of async callables executed after each model response.
+                Guardrails run concurrently with the agent and are awaited before the run completes.
         """
         if model is None or defer_model_check:
             self.model = model
@@ -351,6 +357,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self._mcp_servers = mcp_servers
         self._prepare_tools = prepare_tools
         self.history_processors = history_processors or []
+        self.guardrails = list(guardrails) if guardrails else []
         for tool in tools:
             if isinstance(tool, Tool):
                 self._register_tool(tool)
@@ -699,6 +706,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             output_schema=output_schema,
             output_validators=output_validators,
             history_processors=self.history_processors,
+            guardrails=self.guardrails,
             function_tools=run_function_tools,
             mcp_servers=self._mcp_servers,
             default_retries=self._default_retries,
@@ -736,6 +744,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
                     )
         finally:
             try:
+                if state.guardrail_tasks:
+                    await asyncio.gather(*state.guardrail_tasks)
                 if instrumentation_settings and run_span.is_recording():
                     run_span.set_attributes(self._run_span_end_attributes(state, usage, instrumentation_settings))
             finally:
@@ -1309,6 +1319,24 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
 
     @deprecated('`result_validator` is deprecated, use `output_validator` instead.')
     def result_validator(self, func: Any, /) -> Any: ...
+
+    @overload
+    def guardrail(self, func: Guardrail[AgentDepsT], /) -> Guardrail[AgentDepsT]: ...
+
+    def guardrail(
+        self, func: Guardrail[AgentDepsT] | None = None, /
+    ) -> Guardrail[AgentDepsT] | Callable[[Guardrail[AgentDepsT]], Guardrail[AgentDepsT]]:
+        """Decorator to register an asynchronous guardrail callback."""
+        if func is None:
+
+            def decorator(func_: Guardrail[AgentDepsT]) -> Guardrail[AgentDepsT]:
+                self.guardrails.append(func_)
+                return func_
+
+            return decorator
+        else:
+            self.guardrails.append(func)
+            return func
 
     @overload
     def tool(self, func: ToolFuncContext[AgentDepsT, ToolParams], /) -> ToolFuncContext[AgentDepsT, ToolParams]: ...

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -1,0 +1,39 @@
+import asyncio
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.tools import RunContext
+
+pytestmark = pytest.mark.anyio
+
+
+def simple_model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content="ok")])
+
+
+async def test_guardrail_called():
+    triggered = asyncio.Event()
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        await asyncio.sleep(0)
+        triggered.set()
+
+    agent = Agent(FunctionModel(simple_model), guardrails=[gr])
+    await agent.run("hi")
+    assert triggered.is_set()
+
+
+async def test_guardrail_blocks_until_complete():
+    done = False
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        nonlocal done
+        await asyncio.sleep(0.05)
+        done = True
+
+    agent = Agent(FunctionModel(simple_model), guardrails=[gr])
+    await agent.run("hi")
+    assert done
+


### PR DESCRIPTION
## Summary
- add `Guardrail` callbacks and expose via `Agent.guardrail`
- schedule guardrail tasks after each model response and await on run completion
- document guardrails
- test guardrail behaviour

## Testing
- `pytest -q tests/test_guardrail.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6855dac8afa0832a9bae184e5a85ada1