### PR TITLE
Add asynchronous guardrails

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -553,6 +553,35 @@ print(result2.output)
 
 _(This example is complete, it can be run "as is")_
 
+## Asynchronous guardrails
+
+Guardrails are async callbacks that run beside the agent and are awaited before
+the run completes. There are two kinds:
+
+* **Input guardrails** run whenever a user prompt is added to the message history.
+  By default they run in parallel with the next model request, but you can pass
+  ``is_blocking=True`` to force them to finish before the request is made.
+* **Output guardrails** run after each model response.
+
+Both receive the full message history and a [`RunContext`][pydantic_ai.tools.RunContext],
+allowing you to integrate custom validation or logging logic.
+
+```python {title="guardrails.py"}
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ModelMessage
+
+agent = Agent('openai:gpt-4o')
+
+@agent.input_guardrail(is_blocking=True)
+async def check_input(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+    if 'stop' in getattr(messages[-1], 'content', ''):
+        print('user asked to stop')
+
+@agent.output_guardrail
+async def log_output(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+    print('model responded with', messages[-1])
+```
+
 ## Type safe by design {#static-type-checking}
 
 PydanticAI is designed to work well with static type checkers, like mypy and pyright.

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -34,6 +34,9 @@ __all__ = (
     'build_run_context',
     'capture_run_messages',
     'HistoryProcessor',
+    'InputGuardrailFunc',
+    'InputGuardrail',
+    'OutputGuardrail',
 )
 
 
@@ -66,6 +69,24 @@ HistoryProcessor = Union[
 Can optionally accept a `RunContext` as a parameter.
 """
 
+InputGuardrailFunc = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
+"""The callable invoked for an input guardrail."""
+
+
+@dataclasses.dataclass(slots=True)
+class InputGuardrail(Generic[DepsT]):
+    """An optional blocking callback executed when a user prompt is added."""
+
+    func: InputGuardrailFunc[DepsT]
+    is_blocking: bool = False
+
+    async def __call__(self, messages: list[_messages.ModelMessage], ctx: RunContext[DepsT]) -> Any:
+        return await self.func(messages, ctx)
+
+
+OutputGuardrail = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
+"""A callback executed asynchronously after each model response."""
+
 
 @dataclasses.dataclass
 class GraphAgentState:
@@ -75,6 +96,7 @@ class GraphAgentState:
     usage: _usage.Usage
     retries: int
     run_step: int
+    guardrail_tasks: list[asyncio.Task[Any]] = field(default_factory=list, repr=False)
 
     def increment_retries(self, max_result_retries: int, error: Exception | None = None) -> None:
         self.retries += 1
@@ -106,6 +128,8 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     output_validators: list[_output.OutputValidator[DepsT, OutputDataT]]
 
     history_processors: Sequence[HistoryProcessor[DepsT]]
+    input_guardrails: Sequence[InputGuardrail[DepsT]]
+    output_guardrails: Sequence[OutputGuardrail[DepsT]]
 
     function_tools: dict[str, Tool[DepsT]] = dataclasses.field(repr=False)
     mcp_servers: Sequence[MCPServer] = dataclasses.field(repr=False)
@@ -380,6 +404,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
     ) -> tuple[ModelSettings | None, models.ModelRequestParameters]:
         ctx.state.message_history.append(self.request)
 
+        run_ctx = build_run_context(ctx)
+        for guardrail in ctx.deps.input_guardrails:
+            if guardrail.is_blocking:
+                await guardrail(ctx.state.message_history[:], run_ctx)
+            else:
+                task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+                ctx.state.guardrail_tasks.append(task)
+
         # Check usage
         if ctx.deps.usage_limits:  # pragma: no branch
             ctx.deps.usage_limits.check_before_request(ctx.state.usage)
@@ -403,6 +435,11 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
         # Append the model response to state.message_history
         ctx.state.message_history.append(response)
+
+        run_ctx = build_run_context(ctx)
+        for guardrail in ctx.deps.output_guardrails:
+            task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+            ctx.state.guardrail_tasks.append(task)
 
         # Set the `_result` attribute since we can't use `return` in an async iterator
         self._result = CallToolsNode(response)

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import asyncio
 import dataclasses
 import inspect
 import json
@@ -28,7 +29,12 @@ from . import (
     result,
     usage as _usage,
 )
-from ._agent_graph import HistoryProcessor
+from ._agent_graph import (
+    HistoryProcessor,
+    InputGuardrail,
+    InputGuardrailFunc,
+    OutputGuardrail,
+)
 from .models.instrumented import InstrumentationSettings, InstrumentedModel, instrument_model
 from .result import FinalResult, OutputDataT, StreamedRunResult
 from .settings import ModelSettings, merge_model_settings
@@ -181,6 +187,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        input_guardrails: Sequence[InputGuardrail[AgentDepsT] | InputGuardrailFunc[AgentDepsT]] | None = None,
+        output_guardrails: Sequence[OutputGuardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     @overload
@@ -211,6 +219,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        input_guardrails: Sequence[InputGuardrail[AgentDepsT] | InputGuardrailFunc[AgentDepsT]] | None = None,
+        output_guardrails: Sequence[OutputGuardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     def __init__(
@@ -236,6 +246,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        input_guardrails: Sequence[InputGuardrail[AgentDepsT] | InputGuardrailFunc[AgentDepsT]] | None = None,
+        output_guardrails: Sequence[OutputGuardrail[AgentDepsT]] | None = None,
         **_deprecated_kwargs: Any,
     ):
         """Create an agent.
@@ -282,6 +294,14 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             history_processors: Optional list of callables to process the message history before sending it to the model.
                 Each processor takes a list of messages and returns a modified list of messages.
                 Processors can be sync or async and are applied in sequence.
+            input_guardrails: Optional list of callbacks executed whenever a user prompt is added.
+                Each callback may be provided as a callable or an
+                [`InputGuardrail`][pydantic_ai._agent_graph.InputGuardrail] instance.
+                Guardrails run concurrently with the agent and are awaited before
+                the run completes. Set ``is_blocking=True`` on a guardrail to block
+                the next model request until it finishes.
+            output_guardrails: Optional list of async callables executed after each model response.
+                These run concurrently with the agent and are awaited before the run completes.
         """
         if model is None or defer_model_check:
             self.model = model
@@ -351,6 +371,13 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self._mcp_servers = mcp_servers
         self._prepare_tools = prepare_tools
         self.history_processors = history_processors or []
+        if input_guardrails:
+            self.input_guardrails = [
+                g if isinstance(g, InputGuardrail) else InputGuardrail(g) for g in input_guardrails
+            ]
+        else:
+            self.input_guardrails = []
+        self.output_guardrails = list(output_guardrails) if output_guardrails else []
         for tool in tools:
             if isinstance(tool, Tool):
                 self._register_tool(tool)
@@ -699,6 +726,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             output_schema=output_schema,
             output_validators=output_validators,
             history_processors=self.history_processors,
+            input_guardrails=self.input_guardrails,
+            output_guardrails=self.output_guardrails,
             function_tools=run_function_tools,
             mcp_servers=self._mcp_servers,
             default_retries=self._default_retries,
@@ -736,6 +765,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
                     )
         finally:
             try:
+                if state.guardrail_tasks:
+                    await asyncio.gather(*state.guardrail_tasks)
                 if instrumentation_settings and run_span.is_recording():
                     run_span.set_attributes(self._run_span_end_attributes(state, usage, instrumentation_settings))
             finally:
@@ -1309,6 +1340,50 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
 
     @deprecated('`result_validator` is deprecated, use `output_validator` instead.')
     def result_validator(self, func: Any, /) -> Any: ...
+
+    @overload
+    def input_guardrail(
+        self, func: InputGuardrailFunc[AgentDepsT], /, *, is_blocking: bool = False
+    ) -> InputGuardrail[AgentDepsT]: ...
+
+    def input_guardrail(
+        self,
+        func: InputGuardrailFunc[AgentDepsT] | None = None,
+        /,
+        *,
+        is_blocking: bool = False,
+    ) -> InputGuardrail[AgentDepsT] | Callable[[InputGuardrailFunc[AgentDepsT]], InputGuardrail[AgentDepsT]]:
+        """Decorator to register an asynchronous input guardrail callback."""
+        if func is None:
+
+            def decorator(func_: InputGuardrailFunc[AgentDepsT]) -> InputGuardrail[AgentDepsT]:
+                g = InputGuardrail(func_, is_blocking=is_blocking)
+                self.input_guardrails.append(g)
+                return func_
+
+            return decorator
+        else:
+            g = InputGuardrail(func, is_blocking=is_blocking)
+            self.input_guardrails.append(g)
+            return func
+
+    @overload
+    def output_guardrail(self, func: OutputGuardrail[AgentDepsT], /) -> OutputGuardrail[AgentDepsT]: ...
+
+    def output_guardrail(
+        self, func: OutputGuardrail[AgentDepsT] | None = None, /
+    ) -> OutputGuardrail[AgentDepsT] | Callable[[OutputGuardrail[AgentDepsT]], OutputGuardrail[AgentDepsT]]:
+        """Decorator to register an asynchronous output guardrail callback."""
+        if func is None:
+
+            def decorator(func_: OutputGuardrail[AgentDepsT]) -> OutputGuardrail[AgentDepsT]:
+                self.output_guardrails.append(func_)
+                return func_
+
+            return decorator
+        else:
+            self.output_guardrails.append(func)
+            return func
 
     @overload
     def tool(self, func: ToolFuncContext[AgentDepsT, ToolParams], /) -> ToolFuncContext[AgentDepsT, ToolParams]: ...

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -1,0 +1,88 @@
+import asyncio
+
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai._agent_graph import InputGuardrail
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.tools import RunContext
+
+pytestmark = pytest.mark.anyio
+
+
+def simple_model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content='ok')])
+
+
+async def test_output_guardrail_called():
+    triggered = asyncio.Event()
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        await asyncio.sleep(0)
+        triggered.set()
+
+    agent = Agent(FunctionModel(simple_model), output_guardrails=[gr])
+    await agent.run('hi')
+    assert triggered.is_set()
+
+
+async def test_input_guardrail_called():
+    triggered = asyncio.Event()
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        await asyncio.sleep(0)
+        triggered.set()
+
+    agent = Agent(FunctionModel(simple_model), input_guardrails=[gr])
+    await agent.run('hi')
+    assert triggered.is_set()
+
+
+async def test_output_guardrail_blocks_until_complete():
+    done = False
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        nonlocal done
+        await asyncio.sleep(0.05)
+        done = True
+
+    agent = Agent(FunctionModel(simple_model), output_guardrails=[gr])
+    await agent.run('hi')
+    assert done
+
+
+async def test_input_guardrail_blocks_until_complete_when_specified():
+    events: list[str] = []
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        events.append('gr_start')
+        await asyncio.sleep(0.05)
+        events.append('gr_end')
+
+    def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+        events.append('model')
+        return ModelResponse(parts=[TextPart(content='ok')])
+
+    agent = Agent(FunctionModel(model), input_guardrails=[InputGuardrail(gr, is_blocking=True)])
+    await agent.run('hi')
+    assert events == ['gr_start', 'gr_end', 'model']
+
+
+async def test_input_guardrail_runs_in_parallel_by_default():
+    events: list[str] = []
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        events.append('gr_start')
+        await asyncio.sleep(0.05)
+        events.append('gr_end')
+
+    def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+        events.append('model')
+        return ModelResponse(parts=[TextPart(content='ok')])
+
+    agent = Agent(FunctionModel(model), input_guardrails=[gr])
+    await agent.run('hi')
+    assert events[0] == 'gr_start'
+    assert events[1] == 'model'
+    assert events[-1] == 'gr_end'


### PR DESCRIPTION
## Summary
- support input & output guardrails that run alongside the agent
- await guardrails before finishing the run
- allow blocking input guardrails
- document guardrail usage
- test both blocking and non-blocking guardrails
- fix import order after ruff

## Testing
- `ruff format pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/agent.py tests/test_guardrail.py` *(passed)*
- `ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/agent.py tests/test_guardrail.py` *(passed)*
- `pytest -q tests/test_guardrail.py` *(failed: ModuleNotFoundError: No module named 'httpx')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6855dac8afa0832a9bae184e5a85ada1