### PR TITLE
Add Async Guardrails

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -553,6 +553,35 @@ print(result2.output)
 
 _(This example is complete, it can be run "as is")_
 
+## Asynchronous guardrails
+
+Guardrails are async callbacks that run beside the agent and are awaited before
+the run completes. There are two kinds:
+
+* **Input guardrails** run whenever a user prompt is added to the message history.
+  By default they run in parallel with the next model request, but you can pass
+  ``is_blocking=True`` to force them to finish before the request is made.
+* **Output guardrails** run after each model response.
+
+Both receive the full message history and a [`RunContext`][pydantic_ai.tools.RunContext],
+allowing you to integrate custom validation or logging logic.
+
+```python {title="guardrails.py"}
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ModelMessage
+
+agent = Agent('openai:gpt-4o')
+
+@agent.input_guardrail(is_blocking=True)
+async def check_input(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+    if 'stop' in getattr(messages[-1], 'content', ''):
+        print('user asked to stop')
+
+@agent.output_guardrail
+async def log_output(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+    print('model responded with', messages[-1])
+```
+
 ## Type safe by design {#static-type-checking}
 
 PydanticAI is designed to work well with static type checkers, like mypy and pyright.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,7 +21,7 @@ In typing terms, agents are generic in their dependency and output types, e.g., 
 Here's a toy example of an agent that simulates a roulette wheel:
 
 ```python {title="roulette_wheel.py"}
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RunContext, FinalResult
 
 roulette_agent = Agent(  # (1)!
     'openai:gpt-4o',
@@ -564,7 +564,9 @@ the run completes. There are two kinds:
 * **Output guardrails** run after each model response.
 
 Both receive the full message history and a [`RunContext`][pydantic_ai.tools.RunContext],
-allowing you to integrate custom validation or logging logic.
+allowing you to integrate custom validation or logging logic. If an input guardrail
+returns a [`FinalResult`][pydantic_ai.result.FinalResult], the agent run will stop immediately
+and that result will be returned.
 
 ```python {title="guardrails.py"}
 from pydantic_ai import Agent, RunContext
@@ -573,9 +575,9 @@ from pydantic_ai.messages import ModelMessage
 agent = Agent('openai:gpt-4o')
 
 @agent.input_guardrail(is_blocking=True)
-async def check_input(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+async def check_input(messages: list[ModelMessage], ctx: RunContext[None]) -> FinalResult[str] | None:
     if 'stop' in getattr(messages[-1], 'content', ''):
-        print('user asked to stop')
+        return FinalResult('Stopped by guardrail', None, None)
 
 @agent.output_guardrail
 async def log_output(messages: list[ModelMessage], ctx: RunContext[None]) -> None:

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -12,7 +12,7 @@ from .exceptions import (
 )
 from .format_prompt import format_as_xml
 from .messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
-from .result import ToolOutput
+from .result import FinalResult, ToolOutput
 from .tools import RunContext, Tool
 
 __all__ = (
@@ -43,6 +43,7 @@ __all__ = (
     'RunContext',
     # result
     'ToolOutput',
+    'FinalResult',
     # format_prompt
     'format_as_xml',
 )

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -34,6 +34,9 @@ __all__ = (
     'build_run_context',
     'capture_run_messages',
     'HistoryProcessor',
+    'InputGuardrailFunc',
+    'InputGuardrail',
+    'OutputGuardrail',
 )
 
 
@@ -66,6 +69,24 @@ HistoryProcessor = Union[
 Can optionally accept a `RunContext` as a parameter.
 """
 
+InputGuardrailFunc = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
+"""The callable invoked for an input guardrail."""
+
+
+@dataclasses.dataclass(slots=True)
+class InputGuardrail(Generic[DepsT]):
+    """An optional blocking callback executed when a user prompt is added."""
+
+    func: InputGuardrailFunc[DepsT]
+    is_blocking: bool = False
+
+    async def __call__(self, messages: list[_messages.ModelMessage], ctx: RunContext[DepsT]) -> Any:
+        return await self.func(messages, ctx)
+
+
+OutputGuardrail = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
+"""A callback executed asynchronously after each model response."""
+
 
 @dataclasses.dataclass
 class GraphAgentState:
@@ -75,6 +96,7 @@ class GraphAgentState:
     usage: _usage.Usage
     retries: int
     run_step: int
+    guardrail_tasks: list[asyncio.Task[Any]] = field(default_factory=list, repr=False)
 
     def increment_retries(self, max_result_retries: int, error: Exception | None = None) -> None:
         self.retries += 1
@@ -106,6 +128,8 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     output_validators: list[_output.OutputValidator[DepsT, OutputDataT]]
 
     history_processors: Sequence[HistoryProcessor[DepsT]]
+    input_guardrails: Sequence[InputGuardrail[DepsT]]
+    output_guardrails: Sequence[OutputGuardrail[DepsT]]
 
     function_tools: dict[str, Tool[DepsT]] = dataclasses.field(repr=False)
     mcp_servers: Sequence[MCPServer] = dataclasses.field(repr=False)
@@ -380,6 +404,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
     ) -> tuple[ModelSettings | None, models.ModelRequestParameters]:
         ctx.state.message_history.append(self.request)
 
+        run_ctx = build_run_context(ctx)
+        for guardrail in ctx.deps.input_guardrails:
+            if guardrail.is_blocking:
+                await guardrail(ctx.state.message_history[:], run_ctx)
+            else:
+                task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+                ctx.state.guardrail_tasks.append(task)
+
         # Check usage
         if ctx.deps.usage_limits:  # pragma: no branch
             ctx.deps.usage_limits.check_before_request(ctx.state.usage)
@@ -403,6 +435,11 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
         # Append the model response to state.message_history
         ctx.state.message_history.append(response)
+
+        run_ctx = build_run_context(ctx)
+        for guardrail in ctx.deps.output_guardrails:
+            task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+            ctx.state.guardrail_tasks.append(task)
 
         # Set the `_result` attribute since we can't use `return` in an async iterator
         self._result = CallToolsNode(response)

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -111,7 +111,7 @@ class GraphAgentState:
     usage: _usage.Usage
     retries: int
     run_step: int
-    guardrail_tasks: list[asyncio.Task[Any]] = field(default_factory=list, repr=False)
+    guardrail_tasks: list[Any] = field(default_factory=list, repr=False)
 
     def increment_retries(self, max_result_retries: int, error: Exception | None = None) -> None:
         self.retries += 1
@@ -407,7 +407,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         try:
             model_settings, model_request_parameters = await self._prepare_request(ctx)
         except GuardrailTermination as e:
-            return self._handle_final_result(ctx, e.final_result, [])
+            return End(e.final_result)
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
             ctx.state.message_history, ctx.deps.history_processors, build_run_context(ctx)
@@ -435,6 +435,9 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             else:
                 task = asyncio.create_task(_run_guardrail(guardrail))
                 ctx.state.guardrail_tasks.append(task)
+                await asyncio.sleep(0)
+                if task.done():
+                    await task
 
         # Check usage
         if ctx.deps.usage_limits:  # pragma: no branch

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -69,8 +69,13 @@ HistoryProcessor = Union[
 Can optionally accept a `RunContext` as a parameter.
 """
 
-InputGuardrailFunc = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
-"""The callable invoked for an input guardrail."""
+InputGuardrailFunc = Callable[
+    [list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[result.FinalResult[Any] | None]
+]
+"""The callable invoked for an input guardrail.
+
+Returning a [`FinalResult`][pydantic_ai.result.FinalResult] will terminate the agent run.
+"""
 
 
 @dataclasses.dataclass(slots=True)
@@ -80,8 +85,18 @@ class InputGuardrail(Generic[DepsT]):
     func: InputGuardrailFunc[DepsT]
     is_blocking: bool = False
 
-    async def __call__(self, messages: list[_messages.ModelMessage], ctx: RunContext[DepsT]) -> Any:
+    async def __call__(
+        self, messages: list[_messages.ModelMessage], ctx: RunContext[DepsT]
+    ) -> result.FinalResult[Any] | None:
         return await self.func(messages, ctx)
+
+
+class GuardrailTermination(Exception):
+    """Internal exception used to stop the agent when an input guardrail returns a final result."""
+
+    def __init__(self, final_result: result.FinalResult[Any]):
+        self.final_result = final_result
+        super().__init__()
 
 
 OutputGuardrail = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
@@ -326,7 +341,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
     async def run(
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
-    ) -> CallToolsNode[DepsT, NodeRunEndT]:
+    ) -> CallToolsNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]]:
         if self._result is not None:
             return self._result
 
@@ -385,11 +400,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
     async def _make_request(
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
-    ) -> CallToolsNode[DepsT, NodeRunEndT]:
+    ) -> CallToolsNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]]:
         if self._result is not None:
             return self._result  # pragma: no cover
 
-        model_settings, model_request_parameters = await self._prepare_request(ctx)
+        try:
+            model_settings, model_request_parameters = await self._prepare_request(ctx)
+        except GuardrailTermination as e:
+            return self._handle_final_result(ctx, e.final_result, [])
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
             ctx.state.message_history, ctx.deps.history_processors, build_run_context(ctx)
@@ -405,11 +423,17 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         ctx.state.message_history.append(self.request)
 
         run_ctx = build_run_context(ctx)
+
+        async def _run_guardrail(g: InputGuardrail[DepsT]) -> None:
+            res = await g(ctx.state.message_history[:], run_ctx)
+            if isinstance(res, result.FinalResult):
+                raise GuardrailTermination(res)
+
         for guardrail in ctx.deps.input_guardrails:
             if guardrail.is_blocking:
-                await guardrail(ctx.state.message_history[:], run_ctx)
+                await _run_guardrail(guardrail)
             else:
-                task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+                task = asyncio.create_task(_run_guardrail(guardrail))
                 ctx.state.guardrail_tasks.append(task)
 
         # Check usage

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -744,6 +744,9 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             system_prompt_dynamic_functions=self._system_prompt_dynamic_functions,
         )
 
+        graph_run: (
+            GraphRun[_agent_graph.GraphAgentState, _agent_graph.GraphAgentDeps[AgentDepsT, RunOutputDataT]] | None
+        ) = None
         try:
             async with graph.iter(
                 start_node,
@@ -751,8 +754,9 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
                 deps=graph_deps,
                 span=use_span(run_span) if run_span.is_recording() else None,
                 infer_name=False,
-            ) as graph_run:
-                agent_run = AgentRun(graph_run)
+            ) as graph_run_cm:
+                graph_run = graph_run_cm
+                agent_run = AgentRun(graph_run_cm)
                 yield agent_run
                 if (final_result := agent_run.result) is not None and run_span.is_recording():
                     run_span.set_attribute(
@@ -766,7 +770,11 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         finally:
             try:
                 if state.guardrail_tasks:
-                    await asyncio.gather(*state.guardrail_tasks)
+                    try:
+                        await asyncio.gather(*state.guardrail_tasks)
+                    except _agent_graph.GuardrailTermination as e:
+                        if graph_run is not None:
+                            graph_run._next_node = End(e.final_result)
                 if instrumentation_settings and run_span.is_recording():
                     run_span.set_attributes(self._run_span_end_attributes(state, usage, instrumentation_settings))
             finally:

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import asyncio
 import dataclasses
 import inspect
 import json
@@ -28,7 +29,12 @@ from . import (
     result,
     usage as _usage,
 )
-from ._agent_graph import HistoryProcessor
+from ._agent_graph import (
+    HistoryProcessor,
+    InputGuardrail,
+    InputGuardrailFunc,
+    OutputGuardrail,
+)
 from .models.instrumented import InstrumentationSettings, InstrumentedModel, instrument_model
 from .result import FinalResult, OutputDataT, StreamedRunResult
 from .settings import ModelSettings, merge_model_settings
@@ -181,6 +187,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        input_guardrails: Sequence[InputGuardrail[AgentDepsT] | InputGuardrailFunc[AgentDepsT]] | None = None,
+        output_guardrails: Sequence[OutputGuardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     @overload
@@ -211,6 +219,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        input_guardrails: Sequence[InputGuardrail[AgentDepsT] | InputGuardrailFunc[AgentDepsT]] | None = None,
+        output_guardrails: Sequence[OutputGuardrail[AgentDepsT]] | None = None,
     ) -> None: ...
 
     def __init__(
@@ -236,6 +246,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         end_strategy: EndStrategy = 'early',
         instrument: InstrumentationSettings | bool | None = None,
         history_processors: Sequence[HistoryProcessor[AgentDepsT]] | None = None,
+        input_guardrails: Sequence[InputGuardrail[AgentDepsT] | InputGuardrailFunc[AgentDepsT]] | None = None,
+        output_guardrails: Sequence[OutputGuardrail[AgentDepsT]] | None = None,
         **_deprecated_kwargs: Any,
     ):
         """Create an agent.
@@ -282,6 +294,14 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             history_processors: Optional list of callables to process the message history before sending it to the model.
                 Each processor takes a list of messages and returns a modified list of messages.
                 Processors can be sync or async and are applied in sequence.
+            input_guardrails: Optional list of callbacks executed whenever a user prompt is added.
+                Each callback may be provided as a callable or an
+                [`InputGuardrail`][pydantic_ai._agent_graph.InputGuardrail] instance.
+                Guardrails run concurrently with the agent and are awaited before
+                the run completes. Set ``is_blocking=True`` on a guardrail to block
+                the next model request until it finishes.
+            output_guardrails: Optional list of async callables executed after each model response.
+                These run concurrently with the agent and are awaited before the run completes.
         """
         if model is None or defer_model_check:
             self.model = model
@@ -351,6 +371,13 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self._mcp_servers = mcp_servers
         self._prepare_tools = prepare_tools
         self.history_processors = history_processors or []
+        if input_guardrails:
+            self.input_guardrails = [
+                g if isinstance(g, InputGuardrail) else InputGuardrail(g) for g in input_guardrails
+            ]
+        else:
+            self.input_guardrails = []
+        self.output_guardrails = list(output_guardrails) if output_guardrails else []
         for tool in tools:
             if isinstance(tool, Tool):
                 self._register_tool(tool)
@@ -699,6 +726,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             output_schema=output_schema,
             output_validators=output_validators,
             history_processors=self.history_processors,
+            input_guardrails=self.input_guardrails,
+            output_guardrails=self.output_guardrails,
             function_tools=run_function_tools,
             mcp_servers=self._mcp_servers,
             default_retries=self._default_retries,
@@ -736,6 +765,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
                     )
         finally:
             try:
+                if state.guardrail_tasks:
+                    await asyncio.gather(*state.guardrail_tasks)
                 if instrumentation_settings and run_span.is_recording():
                     run_span.set_attributes(self._run_span_end_attributes(state, usage, instrumentation_settings))
             finally:
@@ -1309,6 +1340,50 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
 
     @deprecated('`result_validator` is deprecated, use `output_validator` instead.')
     def result_validator(self, func: Any, /) -> Any: ...
+
+    @overload
+    def input_guardrail(
+        self, func: InputGuardrailFunc[AgentDepsT], /, *, is_blocking: bool = False
+    ) -> InputGuardrail[AgentDepsT]: ...
+
+    def input_guardrail(
+        self,
+        func: InputGuardrailFunc[AgentDepsT] | None = None,
+        /,
+        *,
+        is_blocking: bool = False,
+    ) -> InputGuardrail[AgentDepsT] | Callable[[InputGuardrailFunc[AgentDepsT]], InputGuardrail[AgentDepsT]]:
+        """Decorator to register an asynchronous input guardrail callback."""
+        if func is None:
+
+            def decorator(func_: InputGuardrailFunc[AgentDepsT]) -> InputGuardrail[AgentDepsT]:
+                g = InputGuardrail(func_, is_blocking=is_blocking)
+                self.input_guardrails.append(g)
+                return func_
+
+            return decorator
+        else:
+            g = InputGuardrail(func, is_blocking=is_blocking)
+            self.input_guardrails.append(g)
+            return func
+
+    @overload
+    def output_guardrail(self, func: OutputGuardrail[AgentDepsT], /) -> OutputGuardrail[AgentDepsT]: ...
+
+    def output_guardrail(
+        self, func: OutputGuardrail[AgentDepsT] | None = None, /
+    ) -> OutputGuardrail[AgentDepsT] | Callable[[OutputGuardrail[AgentDepsT]], OutputGuardrail[AgentDepsT]]:
+        """Decorator to register an asynchronous output guardrail callback."""
+        if func is None:
+
+            def decorator(func_: OutputGuardrail[AgentDepsT]) -> OutputGuardrail[AgentDepsT]:
+                self.output_guardrails.append(func_)
+                return func_
+
+            return decorator
+        else:
+            self.output_guardrails.append(func)
+            return func
 
     @overload
     def tool(self, func: ToolFuncContext[AgentDepsT, ToolParams], /) -> ToolFuncContext[AgentDepsT, ToolParams]: ...

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -86,3 +86,45 @@ async def test_input_guardrail_runs_in_parallel_by_default():
     assert events[0] == 'gr_start'
     assert events[1] == 'model'
     assert events[-1] == 'gr_end'
+
+async def test_input_guardrail_decorator_registers():
+    triggered = asyncio.Event()
+    agent = Agent(FunctionModel(simple_model))
+
+    @agent.input_guardrail
+    async def deco(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        triggered.set()
+
+    await agent.run('hi')
+    assert triggered.is_set()
+
+
+async def test_output_guardrail_decorator_registers():
+    triggered = asyncio.Event()
+    agent = Agent(FunctionModel(simple_model))
+
+    @agent.output_guardrail
+    async def deco(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        triggered.set()
+
+    await agent.run('hi')
+    assert triggered.is_set()
+
+
+async def test_input_guardrail_decorator_blocking():
+    events: list[str] = []
+
+    def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+        events.append('model')
+        return ModelResponse(parts=[TextPart(content='ok')])
+
+    agent = Agent(FunctionModel(model))
+
+    @agent.input_guardrail(is_blocking=True)
+    async def deco(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        events.append('gr_start')
+        await asyncio.sleep(0.05)
+        events.append('gr_end')
+
+    await agent.run('hi')
+    assert events == ['gr_start', 'gr_end', 'model']

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, FinalResult
 from pydantic_ai._agent_graph import InputGuardrail
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -87,6 +87,7 @@ async def test_input_guardrail_runs_in_parallel_by_default():
     assert events[1] == 'model'
     assert events[-1] == 'gr_end'
 
+
 async def test_input_guardrail_decorator_registers():
     triggered = asyncio.Event()
     agent = Agent(FunctionModel(simple_model))
@@ -128,3 +129,20 @@ async def test_input_guardrail_decorator_blocking():
 
     await agent.run('hi')
     assert events == ['gr_start', 'gr_end', 'model']
+
+
+async def test_input_guardrail_can_end_run():
+    called = False
+
+    def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:  # pragma: no cover
+        nonlocal called
+        called = True
+        return ModelResponse(parts=[TextPart(content='should not run')])
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> FinalResult[str]:
+        return FinalResult('blocked', None, None)
+
+    agent = Agent(FunctionModel(model), input_guardrails=[gr])
+    result = await agent.run('hi')
+    assert result.output == 'blocked'
+    assert not called

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -1,0 +1,88 @@
+import asyncio
+
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai._agent_graph import InputGuardrail
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.tools import RunContext
+
+pytestmark = pytest.mark.anyio
+
+
+def simple_model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content='ok')])
+
+
+async def test_output_guardrail_called():
+    triggered = asyncio.Event()
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        await asyncio.sleep(0)
+        triggered.set()
+
+    agent = Agent(FunctionModel(simple_model), output_guardrails=[gr])
+    await agent.run('hi')
+    assert triggered.is_set()
+
+
+async def test_input_guardrail_called():
+    triggered = asyncio.Event()
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        await asyncio.sleep(0)
+        triggered.set()
+
+    agent = Agent(FunctionModel(simple_model), input_guardrails=[gr])
+    await agent.run('hi')
+    assert triggered.is_set()
+
+
+async def test_output_guardrail_blocks_until_complete():
+    done = False
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        nonlocal done
+        await asyncio.sleep(0.05)
+        done = True
+
+    agent = Agent(FunctionModel(simple_model), output_guardrails=[gr])
+    await agent.run('hi')
+    assert done
+
+
+async def test_input_guardrail_blocks_until_complete_when_specified():
+    events: list[str] = []
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        events.append('gr_start')
+        await asyncio.sleep(0.05)
+        events.append('gr_end')
+
+    def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+        events.append('model')
+        return ModelResponse(parts=[TextPart(content='ok')])
+
+    agent = Agent(FunctionModel(model), input_guardrails=[InputGuardrail(gr, is_blocking=True)])
+    await agent.run('hi')
+    assert events == ['gr_start', 'gr_end', 'model']
+
+
+async def test_input_guardrail_runs_in_parallel_by_default():
+    events: list[str] = []
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        events.append('gr_start')
+        await asyncio.sleep(0.05)
+        events.append('gr_end')
+
+    def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+        events.append('model')
+        return ModelResponse(parts=[TextPart(content='ok')])
+
+    agent = Agent(FunctionModel(model), input_guardrails=[gr])
+    await agent.run('hi')
+    assert events[0] == 'gr_start'
+    assert events[1] == 'model'
+    assert events[-1] == 'gr_end'


### PR DESCRIPTION
### Summary

- support input & output guardrails that run alongside the agent
- await guardrails before finishing the run
- allow blocking input guardrails
- document guardrail usage
- test both blocking and non-blocking guardrails