### PR TITLE
Add guardrail termination

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -5,6 +5,7 @@ from .exceptions import (
     AgentRunError,
     FallbackExceptionGroup,
     ModelHTTPError,
+    InputGuardrailTriggered,
     ModelRetry,
     UnexpectedModelBehavior,
     UsageLimitExceeded,
@@ -27,6 +28,7 @@ __all__ = (
     # exceptions
     'AgentRunError',
     'ModelRetry',
+    'InputGuardrailTriggered',
     'ModelHTTPError',
     'FallbackExceptionGroup',
     'UnexpectedModelBehavior',

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -386,6 +386,11 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             raise ctx.state.termination_error
 
         model_settings, model_request_parameters = await self._prepare_request(ctx)
+
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
+
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
             ctx.state.message_history, ctx.deps.history_processors, build_run_context(ctx)
@@ -416,10 +421,20 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             raise ctx.state.termination_error
 
         model_settings, model_request_parameters = await self._prepare_request(ctx)
+
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
+
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
             ctx.state.message_history, ctx.deps.history_processors, build_run_context(ctx)
         )
+
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
+
         model_response = await ctx.deps.model.request(message_history, model_settings, model_request_parameters)
         ctx.state.usage.incr(_usage.Usage())
 
@@ -461,6 +476,11 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
         model_settings = merge_model_settings(ctx.deps.model_settings, None)
         model_request_parameters = await _prepare_request_parameters(ctx)
+
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
+
         return model_settings, model_request_parameters
 
     def _finish_handling(

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -75,7 +75,11 @@ InputGuardrailFunc = Callable[[list[_messages.ModelMessage], RunContext[DepsT]],
 
 @dataclasses.dataclass(slots=True)
 class InputGuardrail(Generic[DepsT]):
-    """An optional blocking callback executed when a user prompt is added."""
+    """Callback executed when a user prompt is added.
+
+    If the callback raises :class:`~pydantic_ai.exceptions.InputGuardrailTriggered`,
+    the agent run will be aborted.
+    """
 
     func: InputGuardrailFunc[DepsT]
     is_blocking: bool = False
@@ -97,6 +101,9 @@ class GraphAgentState:
     retries: int
     run_step: int
     guardrail_tasks: list[asyncio.Task[Any]] = field(default_factory=list, repr=False)
+    terminate_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+    """Event signaled when a guardrail triggers termination."""
+    termination_error: BaseException | None = field(default=None, repr=False)
 
     def increment_retries(self, max_result_retries: int, error: Exception | None = None) -> None:
         self.retries += 1
@@ -138,6 +145,17 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     tracer: Tracer
 
     prepare_tools: ToolsPrepareFunc[DepsT] | None = None
+
+
+def _guardrail_task_done(state: GraphAgentState, task: asyncio.Task[Any]) -> None:
+    """Handle completion of an input guardrail task."""
+    if task.cancelled():
+        return
+    try:
+        task.result()
+    except exceptions.InputGuardrailTriggered as exc:  # pragma: no cover - tests set event
+        state.termination_error = exc
+        state.terminate_event.set()
 
 
 class AgentNode(BaseNode[GraphAgentState, GraphAgentDeps[DepsT, Any], result.FinalResult[NodeRunEndT]]):
@@ -363,6 +381,10 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
     ) -> AsyncIterator[models.StreamedResponse]:
         assert not self._did_stream, 'stream() should only be called once per node'
 
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
+
         model_settings, model_request_parameters = await self._prepare_request(ctx)
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
@@ -389,6 +411,10 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         if self._result is not None:
             return self._result  # pragma: no cover
 
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
+
         model_settings, model_request_parameters = await self._prepare_request(ctx)
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
@@ -402,15 +428,29 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
     async def _prepare_request(
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
     ) -> tuple[ModelSettings | None, models.ModelRequestParameters]:
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
+
         ctx.state.message_history.append(self.request)
 
         run_ctx = build_run_context(ctx)
         for guardrail in ctx.deps.input_guardrails:
             if guardrail.is_blocking:
-                await guardrail(ctx.state.message_history[:], run_ctx)
+                try:
+                    await guardrail(ctx.state.message_history[:], run_ctx)
+                except exceptions.InputGuardrailTriggered as exc:
+                    ctx.state.termination_error = exc
+                    ctx.state.terminate_event.set()
+                    raise
             else:
                 task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+                task.add_done_callback(lambda t, s=ctx.state: _guardrail_task_done(s, t))
                 ctx.state.guardrail_tasks.append(task)
+
+        if ctx.state.terminate_event.is_set():
+            assert ctx.state.termination_error is not None
+            raise ctx.state.termination_error
 
         # Check usage
         if ctx.deps.usage_limits:  # pragma: no branch

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -15,6 +15,7 @@ __all__ = (
     'UnexpectedModelBehavior',
     'UsageLimitExceeded',
     'ModelHTTPError',
+    'InputGuardrailTriggered',
     'FallbackExceptionGroup',
 )
 
@@ -109,6 +110,10 @@ class ModelHTTPError(AgentRunError):
         self.body = body
         message = f'status_code: {status_code}, model_name: {model_name}, body: {body}'
         super().__init__(message)
+
+
+class InputGuardrailTriggered(AgentRunError):
+    """Raised when an input guardrail terminates the run."""
 
 
 class FallbackExceptionGroup(ExceptionGroup):

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, InputGuardrailTriggered
 from pydantic_ai._agent_graph import InputGuardrail
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -128,3 +128,20 @@ async def test_input_guardrail_decorator_blocking():
 
     await agent.run('hi')
     assert events == ['gr_start', 'gr_end', 'model']
+
+
+async def test_guardrail_terminates_run():
+    called = False
+
+    async def guardrail(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+        raise InputGuardrailTriggered('bad input')
+
+    async def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:
+        nonlocal called
+        called = True
+        return ModelResponse(parts=[TextPart(content='ok')])
+
+    agent = Agent(FunctionModel(model), input_guardrails=[guardrail])
+    with pytest.raises(InputGuardrailTriggered):
+        await agent.run('hi')
+    assert not called


### PR DESCRIPTION
## Summary
- raise `InputGuardrailTriggered` when guardrail blocks execution
- expose the new exception in the package exports
- terminate graph execution when guardrails trigger
- add tests for guardrail termination behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68592b68c8ac832a8819c21dc3c57c19