### PR TITLE
Add guardrail termination

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,7 +21,7 @@ In typing terms, agents are generic in their dependency and output types, e.g., 
 Here's a toy example of an agent that simulates a roulette wheel:
 
 ```python {title="roulette_wheel.py"}
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RunContext, FinalResult
 
 roulette_agent = Agent(  # (1)!
     'openai:gpt-4o',
@@ -564,7 +564,9 @@ the run completes. There are two kinds:
 * **Output guardrails** run after each model response.
 
 Both receive the full message history and a [`RunContext`][pydantic_ai.tools.RunContext],
-allowing you to integrate custom validation or logging logic.
+allowing you to integrate custom validation or logging logic. If an input guardrail
+returns a [`FinalResult`][pydantic_ai.result.FinalResult], the agent run will stop immediately
+and that result will be returned.
 
 ```python {title="guardrails.py"}
 from pydantic_ai import Agent, RunContext
@@ -573,9 +575,9 @@ from pydantic_ai.messages import ModelMessage
 agent = Agent('openai:gpt-4o')
 
 @agent.input_guardrail(is_blocking=True)
-async def check_input(messages: list[ModelMessage], ctx: RunContext[None]) -> None:
+async def check_input(messages: list[ModelMessage], ctx: RunContext[None]) -> FinalResult[str] | None:
     if 'stop' in getattr(messages[-1], 'content', ''):
-        print('user asked to stop')
+        return FinalResult('Stopped by guardrail', None, None)
 
 @agent.output_guardrail
 async def log_output(messages: list[ModelMessage], ctx: RunContext[None]) -> None:

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -12,7 +12,7 @@ from .exceptions import (
 )
 from .format_prompt import format_as_xml
 from .messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
-from .result import ToolOutput
+from .result import FinalResult, ToolOutput
 from .tools import RunContext, Tool
 
 __all__ = (
@@ -43,6 +43,7 @@ __all__ = (
     'RunContext',
     # result
     'ToolOutput',
+    'FinalResult',
     # format_prompt
     'format_as_xml',
 )

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -111,7 +111,7 @@ class GraphAgentState:
     usage: _usage.Usage
     retries: int
     run_step: int
-    guardrail_tasks: list[asyncio.Task[Any]] = field(default_factory=list, repr=False)
+    guardrail_tasks: list[Any] = field(default_factory=list, repr=False)
 
     def increment_retries(self, max_result_retries: int, error: Exception | None = None) -> None:
         self.retries += 1
@@ -407,7 +407,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         try:
             model_settings, model_request_parameters = await self._prepare_request(ctx)
         except GuardrailTermination as e:
-            return self._handle_final_result(ctx, e.final_result, [])
+            return End(e.final_result)
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
             ctx.state.message_history, ctx.deps.history_processors, build_run_context(ctx)
@@ -435,6 +435,9 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             else:
                 task = asyncio.create_task(_run_guardrail(guardrail))
                 ctx.state.guardrail_tasks.append(task)
+                await asyncio.sleep(0)
+                if task.done():
+                    await task
 
         # Check usage
         if ctx.deps.usage_limits:  # pragma: no branch

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -69,8 +69,13 @@ HistoryProcessor = Union[
 Can optionally accept a `RunContext` as a parameter.
 """
 
-InputGuardrailFunc = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
-"""The callable invoked for an input guardrail."""
+InputGuardrailFunc = Callable[
+    [list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[result.FinalResult[Any] | None]
+]
+"""The callable invoked for an input guardrail.
+
+Returning a [`FinalResult`][pydantic_ai.result.FinalResult] will terminate the agent run.
+"""
 
 
 @dataclasses.dataclass(slots=True)
@@ -80,8 +85,18 @@ class InputGuardrail(Generic[DepsT]):
     func: InputGuardrailFunc[DepsT]
     is_blocking: bool = False
 
-    async def __call__(self, messages: list[_messages.ModelMessage], ctx: RunContext[DepsT]) -> Any:
+    async def __call__(
+        self, messages: list[_messages.ModelMessage], ctx: RunContext[DepsT]
+    ) -> result.FinalResult[Any] | None:
         return await self.func(messages, ctx)
+
+
+class GuardrailTermination(Exception):
+    """Internal exception used to stop the agent when an input guardrail returns a final result."""
+
+    def __init__(self, final_result: result.FinalResult[Any]):
+        self.final_result = final_result
+        super().__init__()
 
 
 OutputGuardrail = Callable[[list[_messages.ModelMessage], RunContext[DepsT]], Awaitable[Any]]
@@ -326,7 +341,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
     async def run(
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
-    ) -> CallToolsNode[DepsT, NodeRunEndT]:
+    ) -> CallToolsNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]]:
         if self._result is not None:
             return self._result
 
@@ -385,11 +400,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
     async def _make_request(
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
-    ) -> CallToolsNode[DepsT, NodeRunEndT]:
+    ) -> CallToolsNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]]:
         if self._result is not None:
             return self._result  # pragma: no cover
 
-        model_settings, model_request_parameters = await self._prepare_request(ctx)
+        try:
+            model_settings, model_request_parameters = await self._prepare_request(ctx)
+        except GuardrailTermination as e:
+            return self._handle_final_result(ctx, e.final_result, [])
         model_request_parameters = ctx.deps.model.customize_request_parameters(model_request_parameters)
         message_history = await _process_message_history(
             ctx.state.message_history, ctx.deps.history_processors, build_run_context(ctx)
@@ -405,11 +423,17 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         ctx.state.message_history.append(self.request)
 
         run_ctx = build_run_context(ctx)
+
+        async def _run_guardrail(g: InputGuardrail[DepsT]) -> None:
+            res = await g(ctx.state.message_history[:], run_ctx)
+            if isinstance(res, result.FinalResult):
+                raise GuardrailTermination(res)
+
         for guardrail in ctx.deps.input_guardrails:
             if guardrail.is_blocking:
-                await guardrail(ctx.state.message_history[:], run_ctx)
+                await _run_guardrail(guardrail)
             else:
-                task = asyncio.create_task(guardrail(ctx.state.message_history[:], run_ctx))
+                task = asyncio.create_task(_run_guardrail(guardrail))
                 ctx.state.guardrail_tasks.append(task)
 
         # Check usage

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -744,6 +744,9 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             system_prompt_dynamic_functions=self._system_prompt_dynamic_functions,
         )
 
+        graph_run: (
+            GraphRun[_agent_graph.GraphAgentState, _agent_graph.GraphAgentDeps[AgentDepsT, RunOutputDataT]] | None
+        ) = None
         try:
             async with graph.iter(
                 start_node,
@@ -751,8 +754,9 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
                 deps=graph_deps,
                 span=use_span(run_span) if run_span.is_recording() else None,
                 infer_name=False,
-            ) as graph_run:
-                agent_run = AgentRun(graph_run)
+            ) as graph_run_cm:
+                graph_run = graph_run_cm
+                agent_run = AgentRun(graph_run_cm)
                 yield agent_run
                 if (final_result := agent_run.result) is not None and run_span.is_recording():
                     run_span.set_attribute(
@@ -766,7 +770,11 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         finally:
             try:
                 if state.guardrail_tasks:
-                    await asyncio.gather(*state.guardrail_tasks)
+                    try:
+                        await asyncio.gather(*state.guardrail_tasks)
+                    except _agent_graph.GuardrailTermination as e:
+                        if graph_run is not None:
+                            graph_run._next_node = End(e.final_result)
                 if instrumentation_settings and run_span.is_recording():
                     run_span.set_attributes(self._run_span_end_attributes(state, usage, instrumentation_settings))
             finally:

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, FinalResult
 from pydantic_ai._agent_graph import InputGuardrail
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -87,6 +87,7 @@ async def test_input_guardrail_runs_in_parallel_by_default():
     assert events[1] == 'model'
     assert events[-1] == 'gr_end'
 
+
 async def test_input_guardrail_decorator_registers():
     triggered = asyncio.Event()
     agent = Agent(FunctionModel(simple_model))
@@ -128,3 +129,20 @@ async def test_input_guardrail_decorator_blocking():
 
     await agent.run('hi')
     assert events == ['gr_start', 'gr_end', 'model']
+
+
+async def test_input_guardrail_can_end_run():
+    called = False
+
+    def model(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:  # pragma: no cover
+        nonlocal called
+        called = True
+        return ModelResponse(parts=[TextPart(content='should not run')])
+
+    async def gr(messages: list[ModelMessage], ctx: RunContext[None]) -> FinalResult[str]:
+        return FinalResult('blocked', None, None)
+
+    agent = Agent(FunctionModel(model), input_guardrails=[gr])
+    result = await agent.run('hi')
+    assert result.output == 'blocked'
+    assert not called


### PR DESCRIPTION
## Summary
- allow returning FinalResult from input guardrails to end a run
- document guardrail termination
- test input guardrail termination

## Testing
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run coverage run -m pytest` *(fails: ModuleNotFoundError: No module named 'inline_snapshot')*


------
https://chatgpt.com/codex/tasks/task_e_685932a5b0e0832a9c087ba38984f6b5